### PR TITLE
[BUG][#22] Erro 500 ao submeter resposta do quiz devido à ausência de token em chamada Feign interna

### DIFF
--- a/backend/quiz-service/src/main/java/com/avaliakids/quiz/clients/QuestionClient.java
+++ b/backend/quiz-service/src/main/java/com/avaliakids/quiz/clients/QuestionClient.java
@@ -4,9 +4,10 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
+import com.avaliakids.quiz.config.FeignConfig;
 import com.avaliakids.quiz.dto.QuestionDTO;
 
-@FeignClient(name = "api-gateway")
+@FeignClient(name = "api-gateway", configuration = FeignConfig.class)
 public interface QuestionClient {
     @GetMapping("/question-service/questions/id/{id}")
     QuestionDTO getQuestionById(@PathVariable("id") String id);

--- a/backend/quiz-service/src/main/java/com/avaliakids/quiz/config/FeignConfig.java
+++ b/backend/quiz-service/src/main/java/com/avaliakids/quiz/config/FeignConfig.java
@@ -1,0 +1,34 @@
+package com.avaliakids.quiz.config;
+
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+@Configuration
+public class FeignConfig {
+
+    @Bean
+    public RequestInterceptor jwtInterceptor() {
+        return new RequestInterceptor() {
+            @Override
+            public void apply(RequestTemplate template) {
+                RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
+
+                if (requestAttributes instanceof ServletRequestAttributes servletRequestAttributes) {
+                    HttpServletRequest request = servletRequestAttributes.getRequest();
+                    String authHeader = request.getHeader("Authorization");
+
+                    if (authHeader != null && !authHeader.isEmpty()) {
+                        template.header("Authorization", authHeader);
+                    }
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
Durante a submissão de respostas no quiz-service, o sistema retornava erro 500. A causa identificada foi uma chamada Feign interna ao question-service que não propagava o token JWT do usuário autenticado, sendo bloqueada pelo api-gateway com erro 401.

Solução:
Foi implementado um RequestInterceptor no quiz-service para repassar automaticamente o header Authorization presente na requisição original para chamadas Feign internas. Com isso, o question-service passou a aceitar a requisição normalmente e o erro foi resolvido.