### PR TITLE
[BUG][#14] Expo abre já logado

### DIFF
--- a/frontend/app/(tabs)/index.tsx
+++ b/frontend/app/(tabs)/index.tsx
@@ -4,7 +4,7 @@ import { useNavigation } from 'expo-router';
 import { useLayoutEffect } from 'react';
 import CustomHeaderBar from '@/components/ui/CustomHeaderBar';
 
-export default function HomeScreen() {
+export default function IndexScreen() {
   const router = useRouter();
   const navigation = useNavigation();
 

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -3,6 +3,7 @@ import { Stack } from 'expo-router';
 export default function Layout() {
   return (
     <Stack
+      initialRouteName="(tabs)/index"
       screenOptions={{
         headerStyle: {
           backgroundColor: '#1B3C87',


### PR DESCRIPTION
O comportamento esperado é:

Ambos Android e iOS devem iniciar sempre na rota /index.tsx, e dali o usuário escolhe entre login ou cadastro.

✅ Solução
O problema está na forma como a rota inicial está sendo resolvida. Quando o Expo Router encontra um arquivo chamado app/(tabs)/index.tsx, ele espera que o _layout.tsx esteja configurado corretamente para apontar para ele.

